### PR TITLE
clean up root namespace elements in props and csproj files

### DIFF
--- a/src/code/DataJam.EntityFramework/DataJam.EntityFramework.csproj
+++ b/src/code/DataJam.EntityFramework/DataJam.EntityFramework.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <RootNamespace>DataJam.EntityFramework</RootNamespace>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="EntityFramework"/>
     </ItemGroup>

--- a/src/code/DataJam.EntityFrameworkCore/DataJam.EntityFrameworkCore.csproj
+++ b/src/code/DataJam.EntityFrameworkCore/DataJam.EntityFrameworkCore.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
-    <PropertyGroup>
-        <RootNamespace>DataJam.EntityFrameworkCore</RootNamespace>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore"/>
     </ItemGroup>

--- a/src/code/DataJam.Testing/DataJam.Testing.csproj
+++ b/src/code/DataJam.Testing/DataJam.Testing.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <RootNamespace>DataJam.Testing</RootNamespace>
-    </PropertyGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\DataJam\DataJam.csproj"/>
     </ItemGroup>

--- a/src/code/Directory.Build.props
+++ b/src/code/Directory.Build.props
@@ -11,7 +11,6 @@
         <IncludeSource>True</IncludeSource>
         <IncludeSymbols>True</IncludeSymbols>
         <IsPackable>True</IsPackable>
-        <RootNamespace>DataJam</RootNamespace>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 


### PR DESCRIPTION
Pin all root namespace declarations to the MSBuild Project name in the root Directory.Build.props file.